### PR TITLE
Add DEEPSEEK_API_KEY environment variable for test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add DEEPSEEK_API_KEY environment variable to GitHub Actions test job
- This will allow AI matching tests to run successfully in CI environment
- Uses GitHub Actions secrets for secure API key management

## Changes
- Added `env.DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}` to test job
- This resolves the "Error: NotPresent" failures in AI matching tests

## Test Plan
- [x] Tests should pass once DEEPSEEK_API_KEY secret is configured in repository settings
- [x] AI matching functionality will work correctly in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)