### PR TITLE
Fix GitHub Actions binary filename mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       if: matrix.os != 'windows-latest'
       shell: bash
       run: |
-        strip target/${{ matrix.target }}/release/bangumi_rules_builder${{ matrix.extension }}
+        strip target/${{ matrix.target }}/release/bangumi-rules-builder${{ matrix.extension }}
 
     - name: Package Python editor
       shell: bash
@@ -107,14 +107,14 @@ jobs:
 
         # Copy binary
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
-          copy target/${{ matrix.target }}/release/bangumi_rules_builder${{ matrix.extension }} release-package/
+          copy target/${{ matrix.target }}/release/bangumi-rules-builder${{ matrix.extension }} release-package/
           # Copy Python editor files
           xcopy dist\* release-package\ /E /I /Y
           # Copy configuration templates
           copy tasks.json release-package/tasks.json.example
           copy README.md release-package/
         else
-          cp target/${{ matrix.target }}/release/bangumi_rules_builder${{ matrix.extension }} release-package/
+          cp target/${{ matrix.target }}/release/bangumi-rules-builder${{ matrix.extension }} release-package/
           # Copy Python editor files
           cp -r dist/* release-package/
           # Copy configuration templates


### PR DESCRIPTION
## Summary
- Fix binary filename mismatch in GitHub Actions workflow
- Change all occurrences of `bangumi_rules_builder` to `bangumi-rules-builder`
- Resolve macOS build failure due to missing binary file

## Problem
The GitHub Actions workflow was failing on macOS with the error:
```
strip: can't open file: target/aarch64-apple-darwin/release/bangumi_rules_builder (No such file or directory)
```

## Solution
- Updated the binary filename in strip command (line 84)
- Updated the binary filename in Windows copy command (line 110)  
- Updated the binary filename in Linux/macOS copy command (line 117)

## Test Plan
- [ ] Verify GitHub Actions build passes on all platforms
- [ ] Confirm macOS builds complete successfully
- [ ] Check that release artifacts are created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)