### PR TITLE
Fix ARM64 Linux cross-compilation linker error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,13 @@ jobs:
       run: |
         if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
           # Install cross-compilation tools for ring crate
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
             sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            # Set up cross-compilation environment
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
           fi
         elif [ "${{ matrix.os }}" = "windows-latest" ]; then
           # Ensure 7zip is installed (check first to avoid conflicts)


### PR DESCRIPTION
## Summary
- Fix ARM64 Linux cross-compilation by setting proper environment variables
- Resolves 'file in wrong format' linker error by ensuring correct cross-compilation toolchain is used
- Sets CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER, CC_aarch64_unknown_linux_gnu, and CXX_aarch64_unknown_linux_gnu

## Test Plan
- [ ] ARM64 Linux build should complete successfully
- [ ] All other platform builds should continue to work
- [ ] Windows builds should remain fixed (no more 'copy: command not found' errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)