### PR TITLE
Fix ARM64 build dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,12 @@ jobs:
           sudo apt-get update
           # Install cross-compilation tools for ring crate
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
-            # Only install binutils for strip command
-            sudo apt-get install -y binutils-aarch64-linux-gnu
-            # Rust uses its internal linker, no need for gcc toolchain
+            # Install minimal cross-compilation toolchain
+            sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+            # Set up cross-compilation environment
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
           fi
         elif [ "${{ matrix.os }}" = "windows-latest" ]; then
           # Ensure 7zip is installed (check first to avoid conflicts)


### PR DESCRIPTION
## Summary
- Restore  as  crate requires full toolchain
- Keep  for strip command
- Set up proper cross-compilation environment variables

## Issue
Previous optimization removed necessary dependencies causing ARM64 builds to fail

## Test plan
- [x] ARM64 Linux build should complete successfully
- [x] All other platform builds should continue working
- [x] Release artifacts should be generated for all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)