### PR TITLE
Fix: Optimize GitHub Actions workflow to avoid duplicate builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+
+    - name: Run tests
+      shell: bash
+      run: cargo test
+
+    - name: Check code
+      shell: bash
+      run: |
+        cargo check
+        cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - main
   workflow_dispatch:
 
 env:
@@ -140,7 +138,6 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
     - name: Download all artifacts


### PR DESCRIPTION
## Summary
- Remove main branch trigger from release.yml to prevent duplicate builds
- Create separate ci.yml for main branch testing and validation  
- Release workflow now only triggers on tags and manual dispatch
- This eliminates the duplicate build issue when creating releases

## Test plan
- [ ] Merge this PR
- [ ] Create a new tag (e.g., v0.1.1) on main branch
- [ ] Verify that only one build is triggered for the release
- [ ] Confirm release is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)