### PR TITLE
Fix: Remove redundant test job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,26 +155,3 @@ jobs:
           **/*.tar.gz
         generate_release_notes: true
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    env:
-      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy
-
-    - name: Run tests
-      shell: bash
-      run: cargo test
-
-    - name: Check code
-      shell: bash
-      run: |
-        cargo check
-        cargo clippy -- -D warnings


### PR DESCRIPTION
## Summary
- Remove test job from release.yml to avoid redundant testing
- Test job is unnecessary in release workflow since code is already validated by CI
- Release workflow now focuses only on building and packaging binaries
- This reduces build time and avoids duplicate testing

## Test plan
- [ ] Merge this PR
- [ ] Create a new tag (e.g., v0.1.1) to verify release workflow works without tests
- [ ] Confirm release is created successfully with only build jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)