### PR TITLE
Fix: Add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Release


### PR DESCRIPTION
## Summary
- Add 'contents: write' permission to release workflow
- This fixes 403 permission errors when creating releases
- Required for softprops/action-gh-release to create releases

## Test plan
- [ ] Merge this PR
- [ ] Create a new tag (e.g., v0.1.2) to verify release creation works
- [ ] Confirm release is created successfully without 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)