### PR TITLE
Fix Python executable build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,15 +117,12 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           # Windows: no console window
           pyinstaller --onefile --noconsole --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor.exe dist/
         elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
           # Linux: build executable
           pyinstaller --onefile --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor dist/
         elif [ "${{ matrix.os }}" = "macos-latest" ]; then
           # macOS: build executable
           pyinstaller --onefile --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor dist/
         fi
 
     - name: Create release archive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,3 +225,25 @@ debug_date_matching.rs  # Date debugging tools
 - Enable debug prints in date matching functions
 - Check API request/response logging
 - Verify table extraction with intermediate HTML dumps
+
+## GitHub Actions and Release Workflow
+
+### Python Executable Build
+- **PyInstaller Configuration**: Used to build standalone Python GUI executables
+- **Platform-specific Options**:
+  - Windows: `--noconsole` flag to hide command line window
+  - Linux/macOS: Standard executable without console window
+- **Common Issues**:
+  - Linux build failure due to redundant file copy operations
+  - Ensure PyInstaller output directory structure is correct
+
+### GitHub Actions Debugging
+- **Error Investigation**: Use `gh run view --log-failed --job=<job-id>` to examine failed jobs
+- **Log Analysis**: Always check the last 20 lines first to avoid overwhelming output
+  ```bash
+  gh run view --log-failed --job=51864243752 | tail -20
+  ```
+- **Common Build Issues**:
+  - File copy conflicts (source and destination are the same)
+  - PyInstaller dependency resolution
+  - Cross-platform executable naming conventions


### PR DESCRIPTION
## Summary
- Fix Python executable build failure in GitHub Actions workflow
- Remove redundant file copy operations that caused 'same file' errors
- Update CLAUDE.md with GitHub Actions debugging best practices

## Changes
1. **Fixed Python Build Step**: Removed unnecessary  commands that were causing build failures on Linux/macOS platforms
2. **Added Debugging Documentation**: Added new section to CLAUDE.md documenting:
   - GitHub Actions debugging with 
   - Python executable build configuration and common issues
   - Cross-platform PyInstaller usage

## Test Plan
- [x] Verify the fix resolves the Linux build failure
- [x] Ensure Windows builds continue to work correctly
- [x] Confirm macOS builds work without issues
- [x] Test release archive creation with Python executables

## Impact
This fix resolves the GitHub Actions build failure that was preventing successful releases. The Python GUI editor executable will now be properly built for all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)