### PR TITLE
Remove unnecessary scripts from release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,15 +117,12 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           # Windows: no console window
           pyinstaller --onefile --noconsole --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor.exe dist/
         elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
           # Linux: build executable
           pyinstaller --onefile --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor dist/
         elif [ "${{ matrix.os }}" = "macos-latest" ]; then
           # macOS: build executable
           pyinstaller --onefile --name "qb-rule-editor" qb_rule_editor.py
-          cp dist/qb-rule-editor dist/
         fi
 
     - name: Create release archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,6 @@ jobs:
         # Copy Python editor files
         mkdir -p dist
         cp qb_rule_editor.py dist/
-        cp run_editor.bat dist/
-        cp run_editor.ps1 dist/
         cp EDITOR_README.md dist/
 
     - name: Build Python executable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,3 +225,25 @@ debug_date_matching.rs  # Date debugging tools
 - Enable debug prints in date matching functions
 - Check API request/response logging
 - Verify table extraction with intermediate HTML dumps
+
+## GitHub Actions and Release Workflow
+
+### Python Executable Build
+- **PyInstaller Configuration**: Used to build standalone Python GUI executables
+- **Platform-specific Options**:
+  - Windows: `--noconsole` flag to hide command line window
+  - Linux/macOS: Standard executable without console window
+- **Common Issues**:
+  - Linux build failure due to redundant file copy operations
+  - Ensure PyInstaller output directory structure is correct
+
+### GitHub Actions Debugging
+- **Error Investigation**: Use `gh run view --log-failed --job=<job-id>` to examine failed jobs
+- **Log Analysis**: Always check the last 20 lines first to avoid overwhelming output
+  ```bash
+  gh run view --log-failed --job=51864243752 | tail -20
+  ```
+- **Common Build Issues**:
+  - File copy conflicts (source and destination are the same)
+  - PyInstaller dependency resolution
+  - Cross-platform executable naming conventions


### PR DESCRIPTION
## Summary
- Remove run_editor.bat and run_editor.ps1 from release packaging to reduce package size
- Keep scripts in repository for local development use
- Users can run qb-rule-editor.exe directly on Windows without console window
- macOS/Linux users can run executable from command line

## Test plan
- [ ] Create new release v0.1.0 after merge
- [ ] Verify release packages don't contain batch/PS1 scripts
- [ ] Confirm qb-rule-editor.exe runs directly on Windows
- [ ] Test macOS/Linux executables work from command line

🤖 Generated with [Claude Code](https://claude.com/claude-code)