### PR TITLE
Remove .py files from release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,8 @@ jobs:
     - name: Package Python editor
       shell: bash
       run: |
-        # Copy Python editor files
+        # Copy Python editor documentation
         mkdir -p dist
-        cp qb_rule_editor.py dist/
         cp EDITOR_README.md dist/
 
     - name: Build Python executable


### PR DESCRIPTION
## Summary
- Remove qb_rule_editor.py from release packaging
- Keep only compiled executable and documentation

## Why this change?
- Users only need the compiled executable, not source code
- Reduces package size by ~17KB per platform
- Simplifies user experience - no need to choose between .py and .exe
- Maintains all functionality with just the executable

## Test plan
- [ ] Create new release to verify .py files are excluded
- [ ] Confirm executable still works correctly
- [ ] Verify package size reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)