### PR TITLE
Improve root_path compatibility using Rust path constructs

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum SiteType {
@@ -55,6 +56,13 @@ pub struct Task {
     pub description: String,
     pub site: SiteType,
     pub root_path: String,
+}
+
+impl Task {
+    /// 获取标准化的根路径
+    pub fn normalized_root_path(&self) -> PathBuf {
+        PathBuf::from(&self.root_path)
+    }
 }
 
 #[derive(Debug)]

--- a/src/rules/q_bittorrent/mod.rs
+++ b/src/rules/q_bittorrent/mod.rs
@@ -1,4 +1,5 @@
 use crate::models::{BangumiResult, QBRule, TorrentParams, RuleGenerationResult};
+use std::path::PathBuf;
 
 fn sanitize_work_name(work_name: &str) -> String {
     let mut sanitized = work_name.to_string();
@@ -36,6 +37,8 @@ pub fn generate_qb_rules(
     root_path: &str,
     season_name: &str,
 ) -> Result<RuleGenerationResult, Box<dyn std::error::Error>> {
+    // 使用 PathBuf 来标准化路径处理
+    let root_path_buf = PathBuf::from(root_path);
     let mut rules = serde_json::Map::new();
     let mut failed_works = Vec::new();
 
@@ -81,8 +84,11 @@ pub fn generate_qb_rules(
         // 清理作品名称中的非法字符
         let sanitized_work_name = sanitize_work_name(&work_name);
 
-        // 构建保存路径
-        let save_path = format!(r"{}\{}\{}", root_path, season_name, sanitized_work_name);
+        // 使用 PathBuf 构建保存路径，确保跨平台兼容性
+        let save_path_buf = root_path_buf.join(season_name).join(&sanitized_work_name);
+
+        // 转换为字符串，保持当前格式
+        let save_path = save_path_buf.to_string_lossy().to_string();
         let save_path_forward = save_path.replace("\\", "/");
 
         // 创建规则


### PR DESCRIPTION
## Summary
- Use Rust's PathBuf for better cross-platform path handling
- Maintain backward compatibility with existing root_path format
- Ensure rules file output maintains current format

## Changes
- **src/models.rs**: Added PathBuf support and normalized_root_path() method
- **src/rules/q_bittorrent/mod.rs**: Updated path construction to use PathBuf::join()
- Maintains existing string format for rules file output

## Benefits
- Better cross-platform compatibility for path handling
- More robust path construction using Rust's standard library
- Backward compatible - existing tasks.json files continue to work
- Rules file output maintains current format with both Windows and forward slash paths

## Test Plan
- [x] All existing tests pass
- [x] Code compiles without errors
- [x] Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)