### PR TITLE
Release v0.1.3 - Fix undetermined date statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bangumi-rules-builder"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Fix undetermined date statistics tracking bug
- Update version to 0.1.3

## Changes
- Fixed `works_with_undetermined_date` always showing 0
- Modified `parse_table_works` to return both works list and undetermined count
- Updated AI matching logic to properly populate statistics
- Added comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)